### PR TITLE
Migrate to Minecraft 26.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.14-SNAPSHOT'
+    id 'net.fabricmc.fabric-loom' version '1.15.+'
     id 'maven-publish'
 }
 
@@ -18,16 +18,15 @@ repositories {
 dependencies {
     //to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    modImplementation include("me.lucko:fabric-permissions-api:0.6.1")
-    modImplementation include("eu.pb4:sgui:1.11.0+1.21.9")
-    modImplementation include("xyz.nucleoid:server-translations-api:2.5.2+1.21.9-pre3")
-    modImplementation include("eu.pb4:common-economy-api:1.2.0")
+    implementation include("me.lucko:fabric-permissions-api:0.7.0")
+    implementation include("eu.pb4:sgui:2.0.0+26.1")
+    implementation include("xyz.nucleoid:server-translations-api:3.0.1+26.1")
+    implementation include("eu.pb4:common-economy-api:2.0.0")
 }
 
 processResources {
@@ -36,6 +35,11 @@ processResources {
     filesMatching("fabric.mod.json") {
         expand "version": project.version
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    it.options.encoding = "UTF-8"
+    it.options.release = 25
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,12 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.3
-loader_version=0.18.2
+minecraft_version=26.1.1
+loader_version=0.18.4
 # Mod Properties
 mod_version=1.1.14
 maven_group=us.potatoboy
 archives_base_name=headindex
 # Dependencies
 # check this on https://fabricmc.net/develop/
-fabric_version=0.139.5+1.21.11
+fabric_version=0.145.3+26.1.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/us/potatoboy/headindex/BuildableCommand.java
+++ b/src/main/java/us/potatoboy/headindex/BuildableCommand.java
@@ -1,8 +1,8 @@
 package us.potatoboy.headindex;
 
 import com.mojang.brigadier.tree.LiteralCommandNode;
-import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.commands.CommandSourceStack;
 
 public interface BuildableCommand {
-    LiteralCommandNode<ServerCommandSource> build();
+    LiteralCommandNode<CommandSourceStack> build();
 }

--- a/src/main/java/us/potatoboy/headindex/HeadIndex.java
+++ b/src/main/java/us/potatoboy/headindex/HeadIndex.java
@@ -9,8 +9,8 @@ import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.item.PlayerInventoryStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.item.ItemStack;
-import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import us.potatoboy.headindex.api.Head;
@@ -39,16 +39,16 @@ public class HeadIndex implements ModInitializer {
         config = HeadIndexConfig.loadConfig(new File(FabricLoader.getInstance().getConfigDir() + "/head-index.json"));
     }
 
-    public static void tryPurchase(ServerPlayerEntity player, int amount, Runnable onPurchase) {
+    public static void tryPurchase(ServerPlayer player, int amount, Runnable onPurchase) {
         var trueAmount = amount * HeadIndex.config.costAmount;
 
         switch (HeadIndex.config.economyType) {
             case FREE -> onPurchase.run();
             case TAG -> {
                 var stack = new HashSet<ItemVariant>();
-                for (int i = 0; i < player.getInventory().size(); i++) {
-                    ItemStack slotStack = player.getInventory().getStack(i);
-                    if (slotStack.isIn(HeadIndex.config.getCostTag())) {
+                for (int i = 0; i < player.getInventory().getContainerSize(); i++) {
+                    ItemStack slotStack = player.getInventory().getItem(i);
+                    if (slotStack.is(HeadIndex.config.getCostTag())) {
                         stack.add(ItemVariant.of(slotStack));
                     }
                 }
@@ -76,7 +76,7 @@ public class HeadIndex implements ModInitializer {
                 }
             }
             case ECONOMY -> {
-                var account = CommonEconomy.getAccounts(player, HeadIndex.config.getCostCurrency(player.getEntityWorld().getServer())).stream().min(Comparator.comparing(x -> -x.balance())).orElse(null);
+                var account = CommonEconomy.getAccounts(player, HeadIndex.config.getCostCurrency(player.level().getServer())).stream().min(Comparator.comparing(x -> x.balance().negate())).orElse(null);
 
                 if (account != null) {
                     var transaction = account.decreaseBalance(trueAmount);
@@ -88,14 +88,14 @@ public class HeadIndex implements ModInitializer {
             case LEVEL -> {
                 // Cost in experience levels
                 if (player.experienceLevel >= trueAmount) {
-                    player.addExperienceLevels(-trueAmount);
+                    player.giveExperienceLevels(-trueAmount);
                     onPurchase.run();
                 }
             }
             case LEVELPOINTS -> {
                 // Cost in raw experience points
                 if (player.totalExperience >= trueAmount) {
-                    player.addExperience(-trueAmount);
+                    player.giveExperiencePoints(-trueAmount);
                     onPurchase.run();
                 }
             }

--- a/src/main/java/us/potatoboy/headindex/api/Head.java
+++ b/src/main/java/us/potatoboy/headindex/api/Head.java
@@ -4,18 +4,18 @@ import com.google.common.collect.ImmutableMultimap;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.LoreComponent;
-import net.minecraft.component.type.ProfileComponent;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.text.MutableText;
-import net.minecraft.text.Style;
-import net.minecraft.text.Text;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.UUID;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.ItemLore;
+import net.minecraft.world.item.component.ResolvableProfile;
 
 public class Head {
     public final String name;
@@ -42,103 +42,104 @@ public class Head {
         return tags == null ? "" : tags;
     }
 
-    public ItemStack createStack(Text displayName) {
+    public ItemStack createStack(Component displayName) {
         ItemStack stack = new ItemStack(Items.PLAYER_HEAD);
         if (displayName != null) {
-            stack.set(DataComponentTypes.CUSTOM_NAME, displayName);
+            stack.set(DataComponents.CUSTOM_NAME, displayName);
         }
 
         if (tags != null) {
-            stack.set(DataComponentTypes.LORE, new LoreComponent(List.of(Text.literal(tags))));
+            stack.set(DataComponents.LORE, new ItemLore(List.of(Component.literal(tags))));
         }
 
         var props = new PropertyMap(ImmutableMultimap.of("textures", new Property("textures", value, null)));
         var profile = new GameProfile(uuid, "", props);
-        stack.set(DataComponentTypes.PROFILE, ProfileComponent.ofStatic(profile));
+        stack.set(DataComponents.PROFILE, ResolvableProfile.createResolved(profile));
 
         return stack;
     }
 
     public ItemStack createStack() {
-        return createStack(name != null ? Text.literal(name).setStyle(Style.EMPTY.withItalic(false)) : null);
+        return createStack(name != null ? Component.literal(name).setStyle(Style.EMPTY.withItalic(false)) : null);
     }
 
     public enum Category {
         ALPHABET("alphabet",
                 new Head(
                         UUID.fromString("1f961930-4e97-47b7-a5a1-2cc5150f3764"),
-                        "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmMzNWU3MjAyMmUyMjQ5YzlhMTNlNWVkOGE0NTgzNzE3YTYyNjAyNjc3M2Y1NDE2NDQwZDU3M2E5MzhjOTMifX19").createStack()
+                        "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmMzNWU3MjAyMmUyMjQ5YzlhMTNlNWVkOGE0NTgzNzE3YTYyNjAyNjc3M2Y1NDE2NDQwZDU3M2E5MzhjOTMifX19")
         ),
         ANIMALS("animals",
                 new Head(
                         UUID.fromString("6554e785-2a74-481a-9aac-06fc18620a57"),
                         "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWQxN2U0OGM5MjUzZTY3NDczM2NlYjdiYzNkYTdmNTIxNTFlNTI4OWQwMjEyYzhmMmRkNzFlNDE2ZTRlZTY1In19fQ=="
-                ).createStack()
+                )
         ),
         BLOCKS("blocks",
                 new Head(
                         UUID.fromString("795e1ad8-de6d-4edc-a1b5-4e6aad038403"),
                         "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODQ0OWI5MzE4ZTMzMTU4ZTY0YTQ2YWIwZGUxMjFjM2Q0MDAwMGUzMzMyYzE1NzQ5MzJiM2M4NDlkOGZhMGRjMiJ9fX0="
-                ).createStack()
+                )
         ),
         DECORATION("decoration",
                 new Head(
                         UUID.fromString("f3244903-0c01-4f8d-bbc2-4b13338c6a10"),
                         "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmQyYWNiZTVkMmM2MmU0NTViMGQ4ZTY5YzdmNmIwMWJiNjg5NzVmYmZjZmQ5NWMyNzViM2Y5MTYzMTU4NTE5YyJ9fX0="
-                ).createStack()
+                )
         ),
         FOOD_DRINKS("food-drinks",
                 new Head(
                         UUID.fromString("187ab05d-1d27-450b-bea8-a723fd1d3b4a"),
                         "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNWZiNDhlMmI5NjljNGMxYjg2YzVmODJhMmUyMzc5OWY0YTZmMzFjZTAwOWE1ZjkyYjM5ZjViMjUwNTdiMmRkMCJ9fX0="
-                ).createStack()
+                )
         ),
         HUMANS("humans",
                 new Head(
                         UUID.fromString("68cd5f2e-01d3-4ac8-882e-2f7ce487b33b"),
                         "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGNiN2ExNWVkYTFjYmU0N2E4ZDVkN2Y3ODBlODliYmMzNWUwYzE3N2ZjYjljNjQ4MGExMWIwMmNjODE2NWMxYyJ9fX0="
-                ).createStack()
+                )
         ),
         HUMANOID("humanoid",
                 new Head(
                         UUID.fromString("0d8391c2-1748-4869-8631-935ff2d55e07"),
                         "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGNhOGVmMjQ1OGEyYjEwMjYwYjg3NTY1NThmNzY3OWJjYjdlZjY5MWQ0MWY1MzRlZmVhMmJhNzUxMDczMTVjYyJ9fX0="
-                ).createStack()
+                )
         ),
         MISC("miscellaneous",
                 new Head(
                         UUID.fromString("13affe21-698a-4a5e-aff1-ad5183d5f810"),
                         "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTFlNDJiOGY1MGZlZDgyOGQ0Yjk4MWMyN2NhMTNkMDcxY2U4NjNmNjE1NDBiMjc2MzgyNjZmNzcyZDQxZCJ9fX0="
-                ).createStack()
+                )
         ),
         MONSTERS("monsters",
                 new Head(
                         UUID.fromString("a1d05a1e-5937-48ad-973f-70b922d025be"),
                         "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjI2MDJkNWIzNjJhYTE2MzZkMzVhZjIwZmM3MGQyZTc5NDEzMmVhNjRkNjJkMjNmNTVkYjg1MTVhMGM2MTljNyJ9fX0="
-                ).createStack()
+                )
         ),
         PLANTS("plants", new Head(
                 UUID.fromString("6b063c51-34b4-4fcb-be0d-a6aff0783328"),
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZTAxOWVjZTEyNWVjNzlmOTUxNzhlMWFmNGRhMmE4Yjk4MmRlNzFlZDQyYzMxY2FjNGIxZDJmNjY1MzU1ZGY1YSJ9fX0="
-        ).createStack());
+        ));
 
         public final String name;
-        public final ItemStack icon;
+        private final Head iconHead;
 
-        Category(String name, ItemStack icon) {
+        Category(String name, Head iconHead) {
             this.name = name;
-            this.icon = icon;
+            this.iconHead = iconHead;
         }
 
         public ItemStack createStack() {
-            icon.set(DataComponentTypes.CUSTOM_NAME, getDisplayName()
+            ItemStack stack = iconHead.createStack();
+            stack.set(DataComponents.CUSTOM_NAME, getDisplayName()
                             .setStyle(Style.EMPTY.withItalic(false))
             );
-            return icon;
+            return stack;
         }
 
-        public MutableText getDisplayName() {
-            return Text.translatable("text.headindex.category." + name);
+        public MutableComponent getDisplayName() {
+            return Component.translatable("text.headindex.category." + name);
         }
     }
 }

--- a/src/main/java/us/potatoboy/headindex/commands/HeadCommand.java
+++ b/src/main/java/us/potatoboy/headindex/commands/HeadCommand.java
@@ -3,16 +3,16 @@ package us.potatoboy.headindex.commands;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import me.lucko.fabric.api.permissions.v0.Permissions;
-import net.minecraft.server.command.CommandManager;
-import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
 import us.potatoboy.headindex.HeadIndex;
 import us.potatoboy.headindex.commands.subcommands.MenuCommand;
 import us.potatoboy.headindex.commands.subcommands.PlayerCommand;
 import us.potatoboy.headindex.commands.subcommands.SearchCommand;
 
 public class HeadCommand {
-    public HeadCommand(CommandDispatcher<ServerCommandSource> dispatcher) {
-        LiteralCommandNode<ServerCommandSource> root = CommandManager
+    public HeadCommand(CommandDispatcher<CommandSourceStack> dispatcher) {
+        LiteralCommandNode<CommandSourceStack> root = Commands
                 .literal("head")
                 .requires(Permissions.require("headindex.menu", HeadIndex.config.permissionLevel))
                 .executes(MenuCommand::openMenu)

--- a/src/main/java/us/potatoboy/headindex/commands/subcommands/MenuCommand.java
+++ b/src/main/java/us/potatoboy/headindex/commands/subcommands/MenuCommand.java
@@ -4,23 +4,23 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import me.lucko.fabric.api.permissions.v0.Permissions;
-import net.minecraft.server.command.CommandManager;
-import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
 import us.potatoboy.headindex.BuildableCommand;
 import us.potatoboy.headindex.HeadIndex;
 import us.potatoboy.headindex.gui.HeadGui;
 
 public class MenuCommand implements BuildableCommand {
     @Override
-    public LiteralCommandNode<ServerCommandSource> build() {
-        return CommandManager.literal("menu")
+    public LiteralCommandNode<CommandSourceStack> build() {
+        return Commands.literal("menu")
                 .requires(Permissions.require("headindex.menu", HeadIndex.config.permissionLevel))
                 .executes(MenuCommand::openMenu)
                 .build();
     }
 
-    public static int openMenu(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        new HeadGui(context.getSource().getPlayerOrThrow()).open();
+    public static int openMenu(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+        new HeadGui(context.getSource().getPlayerOrException()).open();
 
         return 1;
     }

--- a/src/main/java/us/potatoboy/headindex/commands/subcommands/PlayerCommand.java
+++ b/src/main/java/us/potatoboy/headindex/commands/subcommands/PlayerCommand.java
@@ -4,41 +4,41 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import me.lucko.fabric.api.permissions.v0.Permissions;
-import net.minecraft.command.argument.GameProfileArgumentType;
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.ProfileComponent;
-import net.minecraft.item.Items;
-import net.minecraft.server.command.CommandManager;
-import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.GameProfileArgument;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.ResolvableProfile;
 import us.potatoboy.headindex.BuildableCommand;
 import us.potatoboy.headindex.HeadIndex;
 
 public class PlayerCommand implements BuildableCommand {
     @Override
-    public LiteralCommandNode<ServerCommandSource> build() {
-        return CommandManager.literal("player")
+    public LiteralCommandNode<CommandSourceStack> build() {
+        return Commands.literal("player")
                 .requires(Permissions.require("headindex.playername", HeadIndex.config.permissionLevel))
-                .then(CommandManager.argument("player", GameProfileArgumentType.gameProfile())
+                .then(Commands.argument("player", GameProfileArgument.gameProfile())
                         .executes(PlayerCommand::getPlayer))
                 .build();
     }
 
-    private static int getPlayer(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        var profiles = GameProfileArgumentType.getProfileArgument(context, "player");
+    private static int getPlayer(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+        var profiles = GameProfileArgument.getGameProfiles(context, "player");
         if (profiles.size() != 1) {
-            throw GameProfileArgumentType.UNKNOWN_PLAYER_EXCEPTION.create();
+            throw GameProfileArgument.ERROR_UNKNOWN_PLAYER.create();
         }
         var profile = profiles.iterator().next();
-        var sessionService = context.getSource().getServer().getApiServices().sessionService();
+        var sessionService = context.getSource().getServer().services().sessionService();
         var result = sessionService.fetchProfile(profile.id(), false);
 
         if (result == null) {
-            throw GameProfileArgumentType.UNKNOWN_PLAYER_EXCEPTION.create();
+            throw GameProfileArgument.ERROR_UNKNOWN_PLAYER.create();
         }
 
-        var stack = Items.PLAYER_HEAD.getDefaultStack();
-        stack.set(DataComponentTypes.PROFILE, ProfileComponent.ofStatic(result.profile()));
-        context.getSource().getPlayerOrThrow().getInventory().offerOrDrop(stack);
+        var stack = Items.PLAYER_HEAD.getDefaultInstance();
+        stack.set(DataComponents.PROFILE, ResolvableProfile.createResolved(result.profile()));
+        context.getSource().getPlayerOrException().getInventory().placeItemBackInInventory(stack);
         return 1;
     }
 }

--- a/src/main/java/us/potatoboy/headindex/commands/subcommands/SearchCommand.java
+++ b/src/main/java/us/potatoboy/headindex/commands/subcommands/SearchCommand.java
@@ -5,24 +5,24 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import me.lucko.fabric.api.permissions.v0.Permissions;
-import net.minecraft.server.command.CommandManager;
-import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
 import us.potatoboy.headindex.BuildableCommand;
 import us.potatoboy.headindex.HeadIndex;
 import us.potatoboy.headindex.gui.HeadGui;
 
 public class SearchCommand implements BuildableCommand {
     @Override
-    public LiteralCommandNode<ServerCommandSource> build() {
-        return CommandManager.literal("search")
+    public LiteralCommandNode<CommandSourceStack> build() {
+        return Commands.literal("search")
                 .requires(Permissions.require("headindex.search", HeadIndex.config.permissionLevel))
-                .then(CommandManager.argument("term", StringArgumentType.word())
+                .then(Commands.argument("term", StringArgumentType.word())
                         .executes(SearchCommand::openSearch))
                 .build();
     }
 
-    public static int openSearch(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        new HeadGui(context.getSource().getPlayerOrThrow()).openSearch(StringArgumentType.getString(context, "term"));
+    public static int openSearch(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+        new HeadGui(context.getSource().getPlayerOrException()).openSearch(StringArgumentType.getString(context, "term"));
 
         return 1;
     }

--- a/src/main/java/us/potatoboy/headindex/config/HeadIndexConfig.java
+++ b/src/main/java/us/potatoboy/headindex/config/HeadIndexConfig.java
@@ -3,13 +3,12 @@ package us.potatoboy.headindex.config;
 import com.google.gson.*;
 import eu.pb4.common.economy.api.CommonEconomy;
 import eu.pb4.common.economy.api.EconomyCurrency;
-import net.minecraft.item.Item;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.tag.TagKey;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
-
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
 import java.io.*;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
@@ -36,7 +35,7 @@ public class HeadIndexConfig {
 	public EconomyType economyType = EconomyType.FREE;
 
 	// If using ITEM or TAG or ECONOMY, this identifies the currency/item/tag
-	public Identifier costType = Identifier.of("minecraft", "diamond");
+	public Identifier costType = Identifier.fromNamespaceAndPath("minecraft", "diamond");
 
 	// Amount of the cost
 	public int costAmount = 1;
@@ -44,33 +43,33 @@ public class HeadIndexConfig {
 	/**
 	 * Returns a Text component describing the cost based on the economy type.
 	 */
-	public Text getCost(MinecraftServer server) {
+	public Component getCost(MinecraftServer server) {
 		switch (economyType) {
 			case TAG:
-				return Text.translatable(getCostTag().getTranslationKey())
-						.append(Text.of(" × " + costAmount));
+				return Component.translatable(getCostTag().getTranslationKey())
+						.append(Component.literal(" × " + costAmount));
 			case ITEM:
-				return Text.empty()
-						.append(getCostItem().getName())
-						.append(Text.of(" × " + costAmount));
+			return Component.empty()
+						.append(getCostItem().getDefaultInstance().getDisplayName())
+						.append(Component.literal(" × " + costAmount));
 			case ECONOMY:
 				return getCostCurrency(server)
-						.formatValueText(costAmount, false);
+						.formatValueComponent(costAmount, false);
 			case LEVEL:
 				// Cost in experience levels
-				return Text.translatable("text.headindex.xp.levels", costAmount);
+				return Component.translatable("text.headindex.xp.levels", costAmount);
 			case LEVELPOINTS:
 				// Cost in raw XP points
-				return Text.translatable("text.headindex.xp.points", costAmount);
+				return Component.translatable("text.headindex.xp.points", costAmount);
 			case FREE:
 			default:
-				return Text.empty();
+				return Component.empty();
 		}
 	}
 
 	/** Get the configured Item for ITEM cost type */
 	public Item getCostItem() {
-		return Registries.ITEM.get(costType);
+		return BuiltInRegistries.ITEM.getValue(costType);
 	}
 
 	/** Get the configured EconomyCurrency for ECONOMY cost type */
@@ -80,7 +79,7 @@ public class HeadIndexConfig {
 
 	/** Get the configured TagKey for TAG cost type */
 	public TagKey<Item> getCostTag() {
-		return TagKey.of(Registries.ITEM.getKey(), costType);
+		return TagKey.create(BuiltInRegistries.ITEM.key(), costType);
 	}
 
 	/**

--- a/src/main/java/us/potatoboy/headindex/gui/HeadGui.java
+++ b/src/main/java/us/potatoboy/headindex/gui/HeadGui.java
@@ -109,10 +109,10 @@ public class HeadGui extends SimpleGui {
             this.setSlot(2, outputStack, (index, type, action, gui) -> openSearch(this.getInput()));
         }
 
-        @Override
-        public void onPlayerClose(boolean success) {
-            HeadGui.this.open();
-        }
+//        @Override
+//        public void onRemoved() {
+//            HeadGui.this.open();
+//        }
     }
 
     private class PlayerInputGui extends AnvilInputGui {
@@ -188,9 +188,9 @@ public class HeadGui extends SimpleGui {
             apiDebounce = System.currentTimeMillis() + 500;
         }
 
-        @Override
-        public void onPlayerClose(boolean success) {
-            HeadGui.this.open();
-        }
+//        @Override
+//        public void onRemoved() {
+//            HeadGui.this.open();
+//        }
     }
 }

--- a/src/main/java/us/potatoboy/headindex/gui/HeadGui.java
+++ b/src/main/java/us/potatoboy/headindex/gui/HeadGui.java
@@ -8,16 +8,16 @@ import eu.pb4.sgui.api.elements.GuiElementBuilder;
 import eu.pb4.sgui.api.gui.AnvilInputGui;
 import eu.pb4.sgui.api.gui.SimpleGui;
 import me.lucko.fabric.api.permissions.v0.Permissions;
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.ProfileComponent;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.Style;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.ResolvableProfile;
 import us.potatoboy.headindex.HeadIndex;
 import us.potatoboy.headindex.api.Head;
 import us.potatoboy.headindex.config.HeadIndexConfig;
@@ -28,10 +28,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class HeadGui extends SimpleGui {
-    private final ServerPlayerEntity player;
+    private final ServerPlayer player;
 
-    public HeadGui(ServerPlayerEntity player) {
-        super(ScreenHandlerType.GENERIC_9X2, player, false);
+    public HeadGui(ServerPlayer player) {
+        super(MenuType.GENERIC_9x2, player, false);
 
         this.player = player;
 
@@ -41,13 +41,13 @@ public class HeadGui extends SimpleGui {
             ++index;
         }
 
-        this.setTitle(Text.translatable("text.headindex.title"));
+        this.setTitle(Component.translatable("text.headindex.title"));
 
         if (Permissions.check(player, "headindex.search", HeadIndex.config.permissionLevel)) {
             this.setSlot(this.getSize() - 1, new GuiElementBuilder()
                     .setItem(Items.NAME_TAG)
-                    .setName(Text.translatable("text.headindex.search").setStyle(Style.EMPTY.withItalic(false)))
-                    .setCallback((index1, type1, action) -> {
+                    .setName(Component.translatable("text.headindex.search").setStyle(Style.EMPTY.withItalic(false)))
+                    .setCallback((index1, type1, action, gui) -> {
                         this.close();
                         new SearchInputGui().open();
                     }));
@@ -56,8 +56,8 @@ public class HeadGui extends SimpleGui {
         if (Permissions.check(player, "headindex.playername", HeadIndex.config.permissionLevel)) {
             this.setSlot(this.getSize() - 2, new GuiElementBuilder()
                     .setItem(Items.PLAYER_HEAD)
-                    .setName(Text.translatable("text.headindex.playername").setStyle(Style.EMPTY.withItalic(false).withColor(Formatting.WHITE)))
-                    .setCallback((index1, type1, action) -> {
+                    .setName(Component.translatable("text.headindex.playername").setStyle(Style.EMPTY.withItalic(false).withColor(ChatFormatting.WHITE)))
+                    .setCallback((index1, type1, action, gui) -> {
                         this.close();
                         new PlayerInputGui().open();
                     }));
@@ -80,51 +80,51 @@ public class HeadGui extends SimpleGui {
                 .collect(Collectors.toList());
 
         var headsGui = new PagedHeadsGui(this, heads);
-        headsGui.setTitle(Text.translatable("text.headindex.search.output", search));
+        headsGui.setTitle(Component.translatable("text.headindex.search.output", search));
         headsGui.open();
     }
 
     private class SearchInputGui extends AnvilInputGui {
-        private final ItemStack inputStack = Items.NAME_TAG.getDefaultStack();
-        private final ItemStack outputStack = Items.SLIME_BALL.getDefaultStack();
+        private final ItemStack inputStack = Items.NAME_TAG.getDefaultInstance();
+        private final ItemStack outputStack = Items.SLIME_BALL.getDefaultInstance();
 
         public SearchInputGui() {
             super(HeadGui.this.player, false);
 
-            inputStack.set(DataComponentTypes.CUSTOM_NAME, Text.translatable("text.headindex.search").setStyle(Style.EMPTY.withItalic(false)));
-            outputStack.set(DataComponentTypes.CUSTOM_NAME, Text.translatable("text.headindex.search.output").setStyle(Style.EMPTY.withItalic(false)));
+            inputStack.set(DataComponents.CUSTOM_NAME, Component.translatable("text.headindex.search").setStyle(Style.EMPTY.withItalic(false)));
+            outputStack.set(DataComponents.CUSTOM_NAME, Component.translatable("text.headindex.search.output").setStyle(Style.EMPTY.withItalic(false)));
 
             this.setSlot(1, inputStack);
 
             this.setSlot(2, outputStack, (index, type, action, gui) -> openSearch(this.getInput()));
             this.setDefaultInputValue("");
 
-            this.setTitle(Text.translatable("text.headindex.search"));
+            this.setTitle(Component.translatable("text.headindex.search"));
         }
 
         @Override
         public void onInput(String input) {
             super.onInput(input);
-            outputStack.set(DataComponentTypes.CUSTOM_NAME, Text.translatable("text.headindex.search.output", input).setStyle(Style.EMPTY.withItalic(false)));
+            outputStack.set(DataComponents.CUSTOM_NAME, Component.translatable("text.headindex.search.output", input).setStyle(Style.EMPTY.withItalic(false)));
             this.setSlot(2, outputStack, (index, type, action, gui) -> openSearch(this.getInput()));
         }
 
         @Override
-        public void onClose() {
+        public void onPlayerClose(boolean success) {
             HeadGui.this.open();
         }
     }
 
     private class PlayerInputGui extends AnvilInputGui {
-        private final ItemStack inputStack = Items.PLAYER_HEAD.getDefaultStack();
-        private final ItemStack outputStack = Items.PLAYER_HEAD.getDefaultStack();
+        private final ItemStack inputStack = Items.PLAYER_HEAD.getDefaultInstance();
+        private final ItemStack outputStack = Items.PLAYER_HEAD.getDefaultInstance();
 
         private long apiDebounce = 0;
 
         public PlayerInputGui() {
             super(HeadGui.this.player, false);
 
-            inputStack.set(DataComponentTypes.CUSTOM_NAME, Text.translatable("text.headindex.playername").setStyle(Style.EMPTY.withItalic(false)));
+            inputStack.set(DataComponents.CUSTOM_NAME, Component.translatable("text.headindex.playername").setStyle(Style.EMPTY.withItalic(false)));
 
             this.setSlot(1, inputStack);
 
@@ -132,7 +132,7 @@ public class HeadGui extends SimpleGui {
 
             this.setDefaultInputValue("");
 
-            this.setTitle(Text.translatable("text.headindex.playername"));
+            this.setTitle(Component.translatable("text.headindex.playername"));
         }
 
         @Override
@@ -141,39 +141,39 @@ public class HeadGui extends SimpleGui {
                 apiDebounce = 0;
 
                 CompletableFuture.runAsync(() -> {
-                    MinecraftServer server = player.getEntityWorld().getServer();
+                    MinecraftServer server = player.level().getServer();
 
-                    Optional<NameAndId> possibleProfile = server.getApiServices().profileRepository().findProfileByName(this.getInput());
-                    MinecraftSessionService sessionService = server.getApiServices().sessionService();
+                    Optional<NameAndId> possibleProfile = server.services().profileRepository().findProfileByName(this.getInput());
+                    MinecraftSessionService sessionService = server.services().sessionService();
 
                     if (possibleProfile.isEmpty()) {
-                        outputStack.remove(DataComponentTypes.PROFILE);
+                        outputStack.remove(DataComponents.PROFILE);
                         return;
                     }
 
                     ProfileResult profileResult = sessionService.fetchProfile(possibleProfile.get().id(), false);
                     if (profileResult == null) {
-                        outputStack.remove(DataComponentTypes.PROFILE);
+                        outputStack.remove(DataComponents.PROFILE);
                     } else {
                         GameProfile profile = profileResult.profile();
-                        outputStack.set(DataComponentTypes.PROFILE, ProfileComponent.ofStatic(profile));
+                        outputStack.set(DataComponents.PROFILE, ResolvableProfile.createResolved(profile));
                     }
 
                     var builder = GuiElementBuilder.from(outputStack);
                     if (HeadIndex.config.economyType != HeadIndexConfig.EconomyType.FREE) {
-                        builder.addLoreLine(Text.empty());
-                        builder.addLoreLine(Text.translatable("text.headindex.price", HeadIndex.config.getCost(server)).styled(style -> style.withColor(Formatting.RED)));
+                        builder.addLoreLine(Component.empty());
+                        builder.addLoreLine(Component.translatable("text.headindex.price", HeadIndex.config.getCost(server)).withStyle(style -> style.withColor(ChatFormatting.RED)));
                     }
 
                     this.setSlot(2, builder.asStack(), (index, type, action, gui) ->
                             HeadIndex.tryPurchase(player, 1, () -> {
-                                var cursorStack = getPlayer().currentScreenHandler.getCursorStack();
-                                if (player.currentScreenHandler.getCursorStack().isEmpty()) {
-                                    player.currentScreenHandler.setCursorStack(outputStack.copy());
-                                } else if (ItemStack.areItemsEqual(outputStack, cursorStack) && cursorStack.getCount() < cursorStack.getMaxCount()) {
-                                    cursorStack.increment(1);
+                                var cursorStack = getPlayer().containerMenu.getCarried();
+                                if (player.containerMenu.getCarried().isEmpty()) {
+                                    player.containerMenu.setCarried(outputStack.copy());
+                                } else if (ItemStack.isSameItem(outputStack, cursorStack) && cursorStack.getCount() < cursorStack.getMaxStackSize()) {
+                                    cursorStack.grow(1);
                                 } else {
-                                    player.dropItem(outputStack.copy(), false);
+                                    player.drop(outputStack.copy(), false);
                                 }
                             })
                     );
@@ -189,7 +189,7 @@ public class HeadGui extends SimpleGui {
         }
 
         @Override
-        public void onClose() {
+        public void onPlayerClose(boolean success) {
             HeadGui.this.open();
         }
     }

--- a/src/main/java/us/potatoboy/headindex/gui/PagedHeadsGui.java
+++ b/src/main/java/us/potatoboy/headindex/gui/PagedHeadsGui.java
@@ -2,43 +2,47 @@ package us.potatoboy.headindex.gui;
 
 import eu.pb4.sgui.api.ClickType;
 import eu.pb4.sgui.api.elements.GuiElementBuilder;
-import eu.pb4.sgui.api.gui.GuiInterface;
+import eu.pb4.sgui.api.gui.SlotBasedGui;
 import eu.pb4.sgui.api.gui.layered.Layer;
 import eu.pb4.sgui.api.gui.layered.LayeredGui;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.screen.ScreenHandlerType;
-import net.minecraft.text.Style;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 import us.potatoboy.headindex.HeadIndex;
 import us.potatoboy.headindex.api.Head;
 import us.potatoboy.headindex.config.HeadIndexConfig;
 
 import java.util.List;
 import java.util.UUID;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 
 public class PagedHeadsGui extends LayeredGui {
     public final List<Head> heads;
     public int page = 0;
-    final GuiInterface parent;
+    final SlotBasedGui parent;
     final Layer contentLayer;
     final Layer navigationLayer;
 
-    private static final Style regular = Style.EMPTY.withItalic(false).withColor(Formatting.WHITE);
+    private static final Style regular = Style.EMPTY.withItalic(false).withColor(ChatFormatting.WHITE);
 
-    private static final ItemStack backwardArrow = new Head(
-            UUID.fromString("8aa062dc-9852-42b1-ae37-b2f8a3121c0e"),
-            "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzEwODI5OGZmMmIyNjk1MWQ2ODNlNWFkZTQ2YTQyZTkwYzJmN2M3ZGQ0MWJhYTkwOGJjNTg1MmY4YzMyZTU4MyJ9fX0="
-    ).createStack(Text.translatable("spectatorMenu.previous_page").setStyle(regular));
+    private static ItemStack backwardArrow() {
+        return new Head(
+                UUID.fromString("8aa062dc-9852-42b1-ae37-b2f8a3121c0e"),
+                "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzEwODI5OGZmMmIyNjk1MWQ2ODNlNWFkZTQ2YTQyZTkwYzJmN2M3ZGQ0MWJhYTkwOGJjNTg1MmY4YzMyZTU4MyJ9fX0="
+        ).createStack(Component.translatable("spectatorMenu.previous_page").setStyle(regular));
+    }
 
-    private static final ItemStack forwardArrow = new Head(
-            UUID.fromString("8aa062dc-9852-42b1-ae37-b2f8a3121c0e"),
-            "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzg2MTg1YjFkNTE5YWRlNTg1ZjE4NGMzNGYzZjNlMjBiYjY0MWRlYjg3OWU4MTM3OGU0ZWFmMjA5Mjg3In19fQ=="
-    ).createStack(Text.translatable("spectatorMenu.next_page").setStyle(regular));
+    private static ItemStack forwardArrow() {
+        return new Head(
+                UUID.fromString("8aa062dc-9852-42b1-ae37-b2f8a3121c0e"),
+                "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzg2MTg1YjFkNTE5YWRlNTg1ZjE4NGMzNGYzZjNlMjBiYjY0MWRlYjg3OWU4MTM3OGU0ZWFmMjA5Mjg3In19fQ=="
+        ).createStack(Component.translatable("spectatorMenu.next_page").setStyle(regular));
+    }
 
-    public PagedHeadsGui(GuiInterface parent, List<Head> heads) {
-        super(ScreenHandlerType.GENERIC_9X6, parent.getPlayer(), false);
+    public PagedHeadsGui(SlotBasedGui parent, List<Head> heads) {
+        super(MenuType.GENERIC_9x6, parent.getPlayer(), false);
 
         this.heads = heads;
         this.parent = parent;
@@ -50,8 +54,8 @@ public class PagedHeadsGui extends LayeredGui {
         Layer navigation = new Layer(1, 9);
         this.navigationLayer = navigation;
         navigation.setSlot(0, new GuiElementBuilder(Items.BARRIER)
-                .setName(Text.translatable("text.headindex.back"))
-                .setCallback((index, type, action) -> this.close())
+                .setName(Component.translatable("text.headindex.back"))
+                .setCallback((index, type, action, gui) -> this.close())
         );
         updateNavigation();
         this.addLayer(navigationLayer, 0, 5);
@@ -64,9 +68,9 @@ public class PagedHeadsGui extends LayeredGui {
     private void updateNavigation() {
         navigationLayer.setSlot(
                 3, GuiElementBuilder
-                        .from(this.page != 0 ? backwardArrow : Items.BLACK_STAINED_GLASS_PANE.getDefaultStack())
-                        .setName(Text.translatable("spectatorMenu.previous_page").setStyle(regular))
-                        .setCallback((index, type, action) -> {
+                        .from(this.page != 0 ? backwardArrow() : Items.BLACK_STAINED_GLASS_PANE.getDefaultInstance())
+                        .setName(Component.translatable("spectatorMenu.previous_page").setStyle(regular))
+                        .setCallback((index, type, action, gui) -> {
                             this.page -= 1;
                             if (this.page < 0) {
                                 this.page = 0;
@@ -78,9 +82,9 @@ public class PagedHeadsGui extends LayeredGui {
 
         navigationLayer.setSlot(
                 5, GuiElementBuilder
-                        .from(this.page + 1 < getMaxPage() ? forwardArrow : Items.BLACK_STAINED_GLASS_PANE.getDefaultStack())
-                        .setName(Text.translatable("spectatorMenu.next_page").setStyle(regular))
-                        .setCallback((index, type, action) -> {
+                        .from(this.page + 1 < getMaxPage() ? forwardArrow() : Items.BLACK_STAINED_GLASS_PANE.getDefaultInstance())
+                        .setName(Component.translatable("spectatorMenu.next_page").setStyle(regular))
+                        .setCallback((index, type, action, gui) -> {
                             this.page += 1;
                             if (this.page >= getMaxPage()) {
                                 this.page = getMaxPage() - 1;
@@ -91,7 +95,7 @@ public class PagedHeadsGui extends LayeredGui {
         );
 
         navigationLayer.setSlot(4, new GuiElementBuilder(Items.PAPER)
-                .setName(Text.literal(this.page + 1 + " / " + this.getMaxPage()).setStyle(regular))
+                .setName(Component.literal(this.page + 1 + " / " + this.getMaxPage()).setStyle(regular))
         );
     }
 
@@ -101,13 +105,13 @@ public class PagedHeadsGui extends LayeredGui {
                 Head head = heads.get(i + (this.page * 45));
 				var builder = GuiElementBuilder.from(head.createStack());
 				if (HeadIndex.config.economyType != HeadIndexConfig.EconomyType.FREE) {
-                    builder.addLoreLine(Text.empty());
-					builder.addLoreLine(Text.translatable("text.headindex.price", HeadIndex.config.getCost(getPlayer().getEntityWorld().getServer())).styled(style -> style.withColor(Formatting.RED)));
+                    builder.addLoreLine(Component.empty());
+					builder.addLoreLine(Component.translatable("text.headindex.price", HeadIndex.config.getCost(getPlayer().level().getServer())).withStyle(style -> style.withColor(ChatFormatting.RED)));
 				}
 
-                contentLayer.setSlot(i, builder.asStack(), (index, type, action) -> processHeadClick(head, type));
+                contentLayer.setSlot(i, builder.asStack(), (index, type, action, g) -> processHeadClick(head, type));
             } else {
-                contentLayer.setSlot(i, Items.AIR.getDefaultStack());
+                contentLayer.setSlot(i, Items.AIR.getDefaultInstance());
             }
         }
     }
@@ -120,41 +124,41 @@ public class PagedHeadsGui extends LayeredGui {
     private void processHeadClick(Head head, ClickType type) {
         var player = getPlayer();
 
-        ItemStack cursorStack = getPlayer().currentScreenHandler.getCursorStack();
+        ItemStack cursorStack = getPlayer().containerMenu.getCarried();
         ItemStack headStack = head.createStack();
 
         if (cursorStack.isEmpty()) {
             if (type.shift) {
-                HeadIndex.tryPurchase(player, 1, () -> player.getInventory().insertStack(headStack));
+                HeadIndex.tryPurchase(player, 1, () -> player.getInventory().add(headStack));
             } else if (type.isMiddle) {
-				HeadIndex.tryPurchase(player, headStack.getMaxCount(), () -> {
-					headStack.setCount(headStack.getMaxCount());
-					player.currentScreenHandler.setCursorStack(headStack);
+				HeadIndex.tryPurchase(player, headStack.getMaxStackSize(), () -> {
+					headStack.setCount(headStack.getMaxStackSize());
+					player.containerMenu.setCarried(headStack);
 				});
             } else {
-				HeadIndex.tryPurchase(player, 1, () -> player.currentScreenHandler.setCursorStack(headStack));
+				HeadIndex.tryPurchase(player, 1, () -> player.containerMenu.setCarried(headStack));
             }
-        } else if (cursorStack.getMaxCount() <= cursorStack.getCount()) {
+        } else if (cursorStack.getMaxStackSize() <= cursorStack.getCount()) {
 			return;
-		} else if (ItemStack.areItemsEqual(headStack, cursorStack)) {
+		} else if (ItemStack.isSameItem(headStack, cursorStack)) {
             if (type.isLeft) {
-				HeadIndex.tryPurchase(player, 1, () -> cursorStack.increment(1));
+				HeadIndex.tryPurchase(player, 1, () -> cursorStack.grow(1));
             } else if (type.isRight) {
-				if (HeadIndex.config.economyType == HeadIndexConfig.EconomyType.FREE) cursorStack.decrement(1);
+				if (HeadIndex.config.economyType == HeadIndexConfig.EconomyType.FREE) cursorStack.shrink(1);
             } else if (type.isMiddle) {
-				var amount = headStack.getMaxCount() - cursorStack.getCount();
+				var amount = headStack.getMaxStackSize() - cursorStack.getCount();
 				HeadIndex.tryPurchase(player, amount, () -> {
-					headStack.setCount(headStack.getMaxCount());
-					player.currentScreenHandler.setCursorStack(headStack);
+					headStack.setCount(headStack.getMaxStackSize());
+					player.containerMenu.setCarried(headStack);
 				});
             }
         } else {
-			if (HeadIndex.config.economyType == HeadIndexConfig.EconomyType.FREE) player.currentScreenHandler.setCursorStack(ItemStack.EMPTY);
+			if (HeadIndex.config.economyType == HeadIndexConfig.EconomyType.FREE) player.containerMenu.setCarried(ItemStack.EMPTY);
         }
     }
 
     @Override
-    public void onClose() {
+    public void onPlayerClose(boolean success) {
         parent.open();
     }
 }

--- a/src/main/java/us/potatoboy/headindex/gui/PagedHeadsGui.java
+++ b/src/main/java/us/potatoboy/headindex/gui/PagedHeadsGui.java
@@ -157,8 +157,8 @@ public class PagedHeadsGui extends LayeredGui {
         }
     }
 
-    @Override
-    public void onPlayerClose(boolean success) {
-        parent.open();
-    }
+//    @Override
+//    public void onPlayerClose(boolean success) {
+//        parent.open();
+//    }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,8 +21,8 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.18.2",
-    "fabric": "*",
-    "minecraft": ">=1.21.11"
+    "fabricloader": ">=0.18.4",
+    "fabric-api": "*",
+    "minecraft": ">=26.1.1"
   }
 }


### PR DESCRIPTION
- Upgrade Minecraft version: 1.21.11 -> 26.1.1
- Switch from Yarn to official Mojang mappings
- Migrate Java source via Loom migrateMappings task (Yarn 1.21.11 -> MojMap)
- Upgrade Fabric Loader: 0.18.2 -> 0.18.4
- Upgrade Fabric API: 0.139.5+1.21.11 -> 0.145.3+26.1.1
- Upgrade Fabric Loom: 1.14-SNAPSHOT -> 1.15.+ (new plugin ID: net.fabricmc.fabric-loom)
- Replace modImplementation with implementation (no remapping in 26.1+)
- Upgrade Gradle wrapper: 9.2.0 -> 9.4.0
- Require Java 25 for compilation
- Upgrade sgui: 1.11.0+1.21.9 -> 2.0.0+26.1
  - GuiInterface -> SlotBasedGui
  - Callbacks are now 4-arg (added SlotBasedGui gui parameter)
  - onClose() -> onPlayerClose(boolean success)
- Upgrade server-translations-api: 2.5.2+1.21.9-pre3 -> 3.0.1+26.1
- Upgrade fabric-permissions-api: 0.6.1 -> 0.7.0
- Upgrade common-economy-api: 1.2.0 -> 2.0.0
  - EconomyCurrency.formatValueText() -> formatValueComponent()
  - balance() is now BigInteger; use .negate() instead of unary -
- Fix ItemStack lifecycle: Category icons and PagedHeadsGui arrows are now created lazily (not at class-load time) per 26.1 requirement
- fabric.mod.json: depend on 'fabric-api' not deprecated 'fabric' mod ID
- CI: upgrade to actions/checkout@v4, setup-java@v4, Java 25