### PR TITLE
Add bedrock player head and bedrock client compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ base {
 repositories {
     mavenCentral()
     maven { url = "https://maven.nucleoid.xyz/" }
+
+    // For Floodgate api
+    maven { url = uri("https://repo.opencollab.dev/main/") }
 }
 
 dependencies {
@@ -26,6 +29,9 @@ dependencies {
     implementation include("eu.pb4:sgui:2.1.0+26.2")
     implementation include("xyz.nucleoid:server-translations-api:3.1.0+26.2")
     implementation include("eu.pb4:common-economy-api:2.0.0")
+
+    // Optional GeyserMC integration for bedrock player heads
+    compileOnly('org.geysermc.floodgate:api:2.2.5-SNAPSHOT')
 }
 
 processResources {

--- a/src/main/java/us/potatoboy/headindex/api/GeyserHeadDatabaseAPI.java
+++ b/src/main/java/us/potatoboy/headindex/api/GeyserHeadDatabaseAPI.java
@@ -15,9 +15,14 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
 import com.google.common.collect.ImmutableMultimap;
+import net.minecraft.server.level.ServerPlayer;
 
 public class GeyserHeadDatabaseAPI {
     private static final String GEYSER_GLOBAL_API_SKIN = "https://api.geysermc.org/v2/skin";
+
+    public static boolean isActiveBedrockPlayer(ServerPlayer player) {
+        return FloodgateApi.getInstance().isFloodgatePlayer(player.getUUID());
+    }
 
     public static long getXuidFromUuid(UUID uuid) {
         return uuid.getLeastSignificantBits();

--- a/src/main/java/us/potatoboy/headindex/api/GeyserHeadDatabaseAPI.java
+++ b/src/main/java/us/potatoboy/headindex/api/GeyserHeadDatabaseAPI.java
@@ -1,0 +1,100 @@
+package us.potatoboy.headindex.api;
+
+import com.google.gson.*;
+import net.fabricmc.loader.api.FabricLoader;
+import us.potatoboy.headindex.HeadIndex;
+
+import java.io.*;
+import java.net.URI;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import org.geysermc.floodgate.api.FloodgateApi;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import com.mojang.authlib.properties.PropertyMap;
+import com.google.common.collect.ImmutableMultimap;
+
+public class GeyserHeadDatabaseAPI {
+    private static final String GEYSER_GLOBAL_API_SKIN = "https://api.geysermc.org/v2/skin";
+
+    public static long getXuidFromUuid(UUID uuid) {
+        return uuid.getLeastSignificantBits();
+    }
+
+    public static Collection<net.minecraft.server.players.NameAndId> getProfilesFromPlayerName(String playerName) {
+        var possibleProfile = getProfileFromPlayerName(playerName);
+        if (possibleProfile.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Collections.singleton(possibleProfile.get());
+    }
+
+    public static Optional<net.minecraft.server.players.NameAndId> getProfileFromPlayerName(String playerName) {
+        // Strip off Bedrock player prefix
+        String prefix = FloodgateApi.getInstance().getPlayerPrefix();
+        if (prefix.length() > 0 && !playerName.startsWith(prefix)) {
+            return Optional.empty();
+        }
+        var bedrockName = playerName.substring(prefix.length());
+
+        try {
+            var xuid = FloodgateApi.getInstance().getXuidFor(bedrockName).get();  // Warning - may take time
+            var uuid = FloodgateApi.getInstance().createJavaPlayerId(xuid);
+
+            return Optional.of(new net.minecraft.server.players.NameAndId(uuid, playerName));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<com.mojang.authlib.yggdrasil.response.NameAndId> getAuthlibProfileFromPlayerName(String playerName) {
+        var result = getProfileFromPlayerName(playerName);
+        return result.map(profile -> new com.mojang.authlib.yggdrasil.response.NameAndId(profile.id(), profile.name()));
+    }
+
+    public static GameProfile getGameProfileByUuidName(UUID uuid, String name) {
+        if (! FloodgateApi.getInstance().isFloodgateId(uuid)) {
+            return null;
+        }
+        var xuid = getXuidFromUuid(uuid);
+
+        String url = String.format("%s/%d", GEYSER_GLOBAL_API_SKIN, xuid);
+        var jsonObject = fetchJson(url);
+        if (jsonObject == null) {
+            return null;
+        }
+
+        String value, signature;
+        try {
+            value = jsonObject.get("value").getAsString();
+            signature = jsonObject.get("signature").getAsString();
+        } catch (Exception e) {
+            return null;
+        }
+
+        var props = new PropertyMap(ImmutableMultimap.of("textures", new Property("textures", value, signature)));
+        return new GameProfile(uuid, name, props);
+    }
+
+    private static JsonObject fetchJson(String urlString) {
+        try {
+            URLConnection connection = URI.create(urlString).toURL().openConnection();
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
+            HeadIndex.LOGGER.info("Fetching: {}", urlString);
+            try (InputStreamReader reader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8)) {
+                var response = JsonParser.parseReader(reader).getAsJsonObject();
+                if (response.has("warnings")) {
+                    response.getAsJsonArray("warnings").asList().forEach(HeadIndex.LOGGER::warn);
+                }
+                return response;
+            }
+        } catch (IOException e) {
+            HeadIndex.LOGGER.warn("Fetch failed: {} {}", urlString, e.getMessage());
+            return null;
+        }
+    }
+}
+

--- a/src/main/java/us/potatoboy/headindex/commands/subcommands/MenuCommand.java
+++ b/src/main/java/us/potatoboy/headindex/commands/subcommands/MenuCommand.java
@@ -8,7 +8,9 @@ import net.minecraft.commands.Commands;
 import us.potatoboy.headindex.BuildableCommand;
 import us.potatoboy.headindex.HeadIndex;
 import us.potatoboy.headindex.commands.HIPermissions;
-import us.potatoboy.headindex.gui.HeadGui;
+import us.potatoboy.headindex.gui.HeadGuiFactory;
+
+import net.fabricmc.loader.api.FabricLoader;
 
 public class MenuCommand implements BuildableCommand {
     @Override
@@ -20,7 +22,8 @@ public class MenuCommand implements BuildableCommand {
     }
 
     public static int openMenu(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
-        new HeadGui(context.getSource().getPlayerOrException()).open();
+        final boolean hasFloodgate = FabricLoader.getInstance().isModLoaded("floodgate");
+        HeadGuiFactory.makeHeadGui(context.getSource().getPlayerOrException()).open();
         
         if (HeadIndex.config.demoMode()) {
             context.getSource().sendSystemMessage(HeadIndex.licenseWarn());

--- a/src/main/java/us/potatoboy/headindex/commands/subcommands/PlayerCommand.java
+++ b/src/main/java/us/potatoboy/headindex/commands/subcommands/PlayerCommand.java
@@ -1,5 +1,6 @@
 package us.potatoboy.headindex.commands.subcommands;
 
+import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
@@ -10,7 +11,12 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.ResolvableProfile;
 import us.potatoboy.headindex.BuildableCommand;
+import us.potatoboy.headindex.api.GeyserHeadDatabaseAPI;
 import us.potatoboy.headindex.commands.HIPermissions;
+
+import java.util.Collection;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.server.players.NameAndId;
 
 public class PlayerCommand implements BuildableCommand {
     @Override
@@ -23,20 +29,46 @@ public class PlayerCommand implements BuildableCommand {
     }
 
     private static int getPlayer(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
-        var profiles = GameProfileArgument.getGameProfiles(context, "player");
+        boolean hasFloodgate = FabricLoader.getInstance().isModLoaded("floodgate");
+        Collection<NameAndId> profiles = null;
+        try {
+            profiles = GameProfileArgument.getGameProfiles(context, "player");
+        } catch (CommandSyntaxException e) {
+            // Check if this is a Bedrock player name. If the player is offline no 
+            // bedrock player profile is available in the argument parser.
+
+            if (hasFloodgate) {
+                String fullInput = context.getInput();
+                String playerName = fullInput.substring(fullInput.lastIndexOf(' ')+1);
+                profiles = GeyserHeadDatabaseAPI.getProfilesFromPlayerName(playerName);
+            } else {
+                throw GameProfileArgument.ERROR_UNKNOWN_PLAYER.create();
+            }
+        }
         if (profiles.size() != 1) {
             throw GameProfileArgument.ERROR_UNKNOWN_PLAYER.create();
         }
         var profile = profiles.iterator().next();
+
         var sessionService = context.getSource().getServer().services().sessionService();
         var result = sessionService.fetchProfile(profile.id(), false);
 
-        if (result == null) {
-            throw GameProfileArgument.ERROR_UNKNOWN_PLAYER.create();
+        GameProfile component;
+        if (result != null) {
+            component = result.profile();
+        } else if (hasFloodgate) {
+            // Check if this was an online or recently online bedrock player
+            component = GeyserHeadDatabaseAPI.getGameProfileByUuidName(profile.id(), profile.name());
+        } else {
+            component = null;
+        }
+
+        if (component == null) {
+           throw GameProfileArgument.ERROR_UNKNOWN_PLAYER.create();
         }
 
         var stack = Items.PLAYER_HEAD.getDefaultInstance();
-        stack.set(DataComponents.PROFILE, ResolvableProfile.createResolved(result.profile()));
+        stack.set(DataComponents.PROFILE, ResolvableProfile.createResolved(component));
         context.getSource().getPlayerOrException().getInventory().placeItemBackInInventory(stack);
         return 1;
     }

--- a/src/main/java/us/potatoboy/headindex/gui/HeadGui.java
+++ b/src/main/java/us/potatoboy/headindex/gui/HeadGui.java
@@ -32,7 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class HeadGui extends SimpleGui {
-    private final ServerPlayer player;
+    protected final ServerPlayer player;
     private final boolean hasFloodgate = FabricLoader.getInstance().isModLoaded("floodgate");
 
     public HeadGui(ServerPlayer player) {
@@ -55,7 +55,7 @@ public class HeadGui extends SimpleGui {
                     .setName(Component.translatable("text.headindex.search").setStyle(Style.EMPTY.withItalic(false)))
                     .setCallback((index1, type1, action, gui) -> {
                         this.close();
-                        new SearchInputGui().open();
+                        openSearchInputGui();
                     }));
         }
 
@@ -65,9 +65,17 @@ public class HeadGui extends SimpleGui {
                     .setName(Component.translatable("text.headindex.playername").setStyle(Style.EMPTY.withItalic(false).withColor(ChatFormatting.WHITE)))
                     .setCallback((index1, type1, action, gui) -> {
                         this.close();
-                        new PlayerInputGui().open();
+                        openPlayerInputGui();
                     }));
         }
+    }
+
+    protected void openSearchInputGui() {
+        new SearchInputJavaGui().open();
+    }
+
+    protected void openPlayerInputGui() {
+        new PlayerInputJavaGui().open();
     }
 
     private void addCategoryButton(int index, Category category) {
@@ -94,11 +102,39 @@ public class HeadGui extends SimpleGui {
         headsGui.open();
     }
 
-    private class SearchInputGui extends AnvilInputGui {
+    protected GameProfile  findPlayerGameProfile(String playerName) {
+        MinecraftServer server = player.level().getServer();
+
+        Optional<NameAndId> possibleProfile = server.services().profileRepository().findProfileByName(playerName);
+        MinecraftSessionService sessionService = server.services().sessionService();
+
+        if (possibleProfile.isEmpty() && hasFloodgate) {
+            possibleProfile = GeyserHeadDatabaseAPI.getAuthlibProfileFromPlayerName(playerName);
+        }
+        if (possibleProfile.isEmpty()) {
+            return null;
+        }
+
+        var authlibProfile = possibleProfile.get();
+        ProfileResult profileResult = sessionService.fetchProfile(authlibProfile.id(), false);
+
+        GameProfile profile = null;
+        if (profileResult != null) {
+            profile = profileResult.profile();
+        }
+
+        if (profile == null && hasFloodgate) {
+            profile = GeyserHeadDatabaseAPI.getGameProfileByUuidName(authlibProfile.id(), authlibProfile.name());
+        }
+
+        return profile;
+    }
+
+    protected class SearchInputJavaGui extends AnvilInputGui {
         private final ItemStack inputStack = Items.NAME_TAG.getDefaultInstance();
         private final ItemStack outputStack = Items.SLIME_BALL.getDefaultInstance();
 
-        public SearchInputGui() {
+        public SearchInputJavaGui() {
             super(HeadGui.this.player, false);
 
             inputStack.set(DataComponents.CUSTOM_NAME, Component.translatable("text.headindex.search").setStyle(Style.EMPTY.withItalic(false)));
@@ -125,13 +161,13 @@ public class HeadGui extends SimpleGui {
 //        }
     }
 
-    private class PlayerInputGui extends AnvilInputGui {
+    private class PlayerInputJavaGui extends AnvilInputGui {
         private final ItemStack inputStack = Items.PLAYER_HEAD.getDefaultInstance();
         private final ItemStack outputStack = Items.PLAYER_HEAD.getDefaultInstance();
 
         private long apiDebounce = 0;
 
-        public PlayerInputGui() {
+        public PlayerInputJavaGui() {
             super(HeadGui.this.player, false);
 
             inputStack.set(DataComponents.CUSTOM_NAME, Component.translatable("text.headindex.playername").setStyle(Style.EMPTY.withItalic(false)));
@@ -152,29 +188,8 @@ public class HeadGui extends SimpleGui {
 
                 CompletableFuture.runAsync(() -> {
                     MinecraftServer server = player.level().getServer();
-
-                    Optional<NameAndId> possibleProfile = server.services().profileRepository().findProfileByName(this.getInput());
-                    MinecraftSessionService sessionService = server.services().sessionService();
-
-                    if (possibleProfile.isEmpty() && hasFloodgate) {
-                        possibleProfile = GeyserHeadDatabaseAPI.getAuthlibProfileFromPlayerName(this.getInput());
-                    }
-                    if (possibleProfile.isEmpty()) {
-                        outputStack.remove(DataComponents.PROFILE);
-                        return;
-                    }
-
-                    var authlibProfile = possibleProfile.get();
-                    ProfileResult profileResult = sessionService.fetchProfile(authlibProfile.id(), false);
-
-                    GameProfile profile = null;
-                    if (profileResult != null) {
-                        profile = profileResult.profile();
-                    }
-
-                    if (profile == null && hasFloodgate) {
-                        profile = GeyserHeadDatabaseAPI.getGameProfileByUuidName(authlibProfile.id(), authlibProfile.name());
-                    }
+                    String playerName = this.getInput();
+                    var profile = findPlayerGameProfile(playerName);
 
                     if (profile == null) {
                         outputStack.remove(DataComponents.PROFILE);

--- a/src/main/java/us/potatoboy/headindex/gui/HeadGui.java
+++ b/src/main/java/us/potatoboy/headindex/gui/HeadGui.java
@@ -19,8 +19,11 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.ResolvableProfile;
 import us.potatoboy.headindex.HeadIndex;
 import us.potatoboy.headindex.api.Category;
+import us.potatoboy.headindex.api.GeyserHeadDatabaseAPI;
 import us.potatoboy.headindex.commands.HIPermissions;
 import us.potatoboy.headindex.config.HeadIndexConfig;
+
+import net.fabricmc.loader.api.FabricLoader;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,6 +33,7 @@ import java.util.stream.Collectors;
 
 public class HeadGui extends SimpleGui {
     private final ServerPlayer player;
+    private final boolean hasFloodgate = FabricLoader.getInstance().isModLoaded("floodgate");
 
     public HeadGui(ServerPlayer player) {
         super(MenuType.GENERIC_9x2, player, false);
@@ -152,16 +156,29 @@ public class HeadGui extends SimpleGui {
                     Optional<NameAndId> possibleProfile = server.services().profileRepository().findProfileByName(this.getInput());
                     MinecraftSessionService sessionService = server.services().sessionService();
 
+                    if (possibleProfile.isEmpty() && hasFloodgate) {
+                        possibleProfile = GeyserHeadDatabaseAPI.getAuthlibProfileFromPlayerName(this.getInput());
+                    }
                     if (possibleProfile.isEmpty()) {
                         outputStack.remove(DataComponents.PROFILE);
                         return;
                     }
 
-                    ProfileResult profileResult = sessionService.fetchProfile(possibleProfile.get().id(), false);
-                    if (profileResult == null) {
+                    var authlibProfile = possibleProfile.get();
+                    ProfileResult profileResult = sessionService.fetchProfile(authlibProfile.id(), false);
+
+                    GameProfile profile = null;
+                    if (profileResult != null) {
+                        profile = profileResult.profile();
+                    }
+
+                    if (profile == null && hasFloodgate) {
+                        profile = GeyserHeadDatabaseAPI.getGameProfileByUuidName(authlibProfile.id(), authlibProfile.name());
+                    }
+
+                    if (profile == null) {
                         outputStack.remove(DataComponents.PROFILE);
                     } else {
-                        GameProfile profile = profileResult.profile();
                         outputStack.set(DataComponents.PROFILE, ResolvableProfile.createResolved(profile));
                     }
 

--- a/src/main/java/us/potatoboy/headindex/gui/HeadGuiBedrock.java
+++ b/src/main/java/us/potatoboy/headindex/gui/HeadGuiBedrock.java
@@ -1,0 +1,98 @@
+package us.potatoboy.headindex.gui;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+import com.mojang.authlib.yggdrasil.ProfileResult;
+import com.mojang.authlib.yggdrasil.response.NameAndId;
+import eu.pb4.sgui.api.elements.GuiElementBuilder;
+import eu.pb4.sgui.api.gui.AnvilInputGui;
+import eu.pb4.sgui.api.gui.SimpleGui;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.ResolvableProfile;
+import us.potatoboy.headindex.HeadIndex;
+import us.potatoboy.headindex.api.Category;
+import us.potatoboy.headindex.api.GeyserHeadDatabaseAPI;
+import us.potatoboy.headindex.commands.HIPermissions;
+import us.potatoboy.headindex.config.HeadIndexConfig;
+import us.potatoboy.headindex.gui.HeadGui;
+
+import org.geysermc.floodgate.api.FloodgateApi;
+import org.geysermc.cumulus.form.CustomForm;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class HeadGuiBedrock extends HeadGui {
+
+    public HeadGuiBedrock(ServerPlayer player) {
+        super(player);
+    }
+
+    @Override
+    protected void openSearchInputGui() {
+        new SearchInputBedrockGui().open();
+    }
+
+    @Override
+    protected void openPlayerInputGui() {
+        new PlayerInputBedrockGui().open();
+    }
+
+
+    protected class SearchInputBedrockGui {
+        public SearchInputBedrockGui() {
+        }
+
+        public void open() {
+            FloodgateApi.getInstance().sendForm(player.getUUID(),
+                CustomForm.builder()
+                .title(Component.translatable("text.headindex.search").getString())
+                .input(Component.translatable("text.headindex.search.output").getString(), "search")
+                .validResultHandler(response -> openSearch(response.next()))
+                );
+        }
+    }
+
+    protected class PlayerInputBedrockGui {
+        private CustomForm form;
+        public PlayerInputBedrockGui() {
+            form = CustomForm.builder()
+                .title(Component.translatable("text.headindex.playername").getString())
+                .input(Component.translatable("text.headindex.playername.output").getString(), "player")
+                .validResultHandler((form, response) -> { executeSearch(response.asInput(0)); } )
+                .build();
+        }
+
+        public void open() {
+            FloodgateApi.getInstance().sendForm(player.getUUID(), form);
+        }
+
+        private void executeSearch(String playerName) {
+                CompletableFuture.runAsync(() -> {
+                    var profile = findPlayerGameProfile(playerName);
+
+                    if (profile == null) {
+                        return;
+                    }
+
+                    ItemStack outputStack = Items.PLAYER_HEAD.getDefaultInstance();
+                    outputStack.set(DataComponents.PROFILE, ResolvableProfile.createResolved(profile));
+
+                    HeadIndex.tryPurchase(player, 1, () -> {
+                        getPlayer().getInventory().placeItemBackInInventory(outputStack);
+                        });
+                });
+        }
+    }
+}

--- a/src/main/java/us/potatoboy/headindex/gui/HeadGuiFactory.java
+++ b/src/main/java/us/potatoboy/headindex/gui/HeadGuiFactory.java
@@ -1,0 +1,27 @@
+package us.potatoboy.headindex.gui;
+
+import us.potatoboy.headindex.api.GeyserHeadDatabaseAPI;
+import us.potatoboy.headindex.gui.HeadGuiBedrock;
+import us.potatoboy.headindex.gui.HeadGui;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.fabricmc.loader.api.FabricLoader;
+
+public class HeadGuiFactory {
+   // Not meant to be instantiated
+   private HeadGuiFactory() {
+   }
+
+   public static HeadGui makeHeadGui(ServerPlayer player) {
+       boolean hasFloodgate = FabricLoader.getInstance().isModLoaded("floodgate");
+       boolean isBedrockPlayer = false;
+       if (hasFloodgate) {
+           isBedrockPlayer = GeyserHeadDatabaseAPI.isActiveBedrockPlayer(player);
+       }
+
+       if (isBedrockPlayer) {
+           return new HeadGuiBedrock(player);
+       }
+       return new HeadGui(player);
+   }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,5 +27,8 @@
     "fabricloader": ">=0.18.4",
     "fabric-api": "*",
     "minecraft": ">=26.2"
+  },
+  "suggests": {
+    "floodgate": ">=2.2.6"
   }
 }


### PR DESCRIPTION
This is a series of commits that add two things:
- support for bedrock player heads
- support for bedrock clients (different implementation for the player and search guis)

Both of these require the mod Floodgate to be installed to work. If that mod is not present HeadIndex work just as before.

Let me know what changes you want.